### PR TITLE
Fixed Pair.ts property definition

### DIFF
--- a/src/PSON/Pair.ts
+++ b/src/PSON/Pair.ts
@@ -10,8 +10,8 @@ import * as ByteBuffer from "bytebuffer";
  * @abstract
  */
 export abstract class Pair {
-	protected encoder: Encoder;
-	protected decoder: Decoder;
+	protected encoder!: Encoder;
+	protected decoder!: Decoder;
 
 	/**
 	 * Encodes JSON to PSON.


### PR DESCRIPTION
Fixes "src/PSON/Pair.ts:14:12 - error TS2564: Property 'decoder' has no initializer and is not definitely assigned in the constructor." error.